### PR TITLE
Remove extra space in mentorship/mentees/README.md

### DIFF
--- a/mentorship/mentees/README.md
+++ b/mentorship/mentees/README.md
@@ -2,7 +2,7 @@
 
 ### Benefits  <a id="Mentees-Benefits"></a>
 
-Mentees can grow their career by diving right into the open source community to learn  from top project contributors. They can build expertise with hands-on experience and free access to premium Linux Foundation training.
+Mentees can grow their career by diving right into the open source community to learn from top project contributors. They can build expertise with hands-on experience and free access to premium Linux Foundation training.
 
 {% hint style="info" %}
 **Eligibility Rules** 


### PR DESCRIPTION
The extra space shows up on the wiki page, but not on the markdown file that holds the content. Remove extra space in the markdown so the wiki page renders without the extra space.