### PR TITLE
Fix broken link

### DIFF
--- a/mentorship/mentees/README.md
+++ b/mentorship/mentees/README.md
@@ -26,7 +26,7 @@ The following eligibility rules apply to all mentee applicants.
 
 Mentee stipends are paid in installments tied to mentee evaluations and satisfactory progress with program deliverables up to that point. The final installment is paid upon successful completion of the program. For additional stipend information and amounts please refer to [Mentee Stipends section. ](../mentee-stipends/)
 
-To be eligible for a mentorship stipend mentees must receive a satisfactory progress evaluation before they [submit an Expensify Report ](https://docs.linuxfoundation.org/docs/communitybridge/mentorship/mentees/submit-a-report-to-receive-a-mentorship-stipend)
+To be eligible for a mentorship stipend mentees must receive a satisfactory progress evaluation before they [submit an Expensify Report ](https://docs.linuxfoundation.org/lfx/mentorship/mentees/submit-a-report-to-receive-a-mentorship-stipend)
 
 ### Your Activities <a id="Mentees-YourActivities"></a>
 


### PR DESCRIPTION
The "submit an Expensify Report" link is broken. Fixed it.

Old link- https://docs.linuxfoundation.org/lfx/communitybridge/mentorship/mentees/submit-a-report-to-receive-a-mentorship-stipend

New link- https://docs.linuxfoundation.org/lfx/mentorship/mentees/submit-a-report-to-receive-a-mentorship-stipend