### PR TITLE
Remove extra stars from CLA project managers doc

### DIFF
--- a/easycla/v2-current/project-managers/README.md
+++ b/easycla/v2-current/project-managers/README.md
@@ -20,7 +20,7 @@ For EasyCLA integrated GitHub organizations and repositories, EasyCLA sends emai
 
 * **Repository Renamed:** EasyCLA updates GitHub repository table entry to match the new GitHub repository name, and notifies the project manager.
 * **Repository Archived:** EasyCLA takes no action, however notifies the project manager that the repository is archived.
-* **Repository Deleted:** EasyCLA **** disables the repository, and notifies the project manager.
-* **Repository Moved to a Different Organization:**&#x20;
-  * If **** an EasyCLA enabled repository is moved from one organization to another within the same CLA Group, EasyCLA simply notifies the project manager about the action.
-  * If **** a repository is moved from one organization to another where EasyCLA is not configured or the CLA Group is different, EasyCLA disables the repository, and notifies the project manager.
+* **Repository Deleted:** EasyCLA disables the repository, and notifies the project manager.
+* **Repository Moved to a Different Organization:**
+  * If an EasyCLA enabled repository is moved from one organization to another within the same CLA Group, EasyCLA simply notifies the project manager about the action.
+  * If a repository is moved from one organization to another where EasyCLA is not configured or the CLA Group is different, EasyCLA disables the repository, and notifies the project manager.


### PR DESCRIPTION
Removes some unnecessary "*" characters from the document along with an HTML space character.